### PR TITLE
Add useragent

### DIFF
--- a/sedas_pyapi/sedas_api.py
+++ b/sedas_pyapi/sedas_api.py
@@ -311,7 +311,6 @@ class SeDASAPI:
         req = Request(url, headers=self.headers)
         try:
             decoded = json.load(urlopen(req))
-            _logger.debug(json.dumps(decoded))
             if len(decoded) >= 1 and 'downloadUrl' in decoded[0]:
                 return decoded[0]['downloadUrl']
             return None

--- a/sedas_pyapi/sedas_api.py
+++ b/sedas_pyapi/sedas_api.py
@@ -35,7 +35,7 @@ class SeDASAPI:
     authentication_url = f"{base_url}authentication"
     search_url = f"{base_url}search"
     sensor_url = f"{base_url}sensors"
-    headers = {"Content-Type": "application/json", "Authorization": None}
+    headers = {"Content-Type": "application/json", "User-Agent": "sedas_pyapi", "Authorization": None}
 
     _token = None
     _token_time = None
@@ -311,6 +311,7 @@ class SeDASAPI:
         req = Request(url, headers=self.headers)
         try:
             decoded = json.load(urlopen(req))
+            _logger.debug(json.dumps(decoded))
             if len(decoded) >= 1 and 'downloadUrl' in decoded[0]:
                 return decoded[0]['downloadUrl']
             return None


### PR DESCRIPTION
The firewall guarding the SeDAS API gets cranky if a request doesn't have a User-Agent header. Unless you are on the catapult corp network, which is why I'd not noticed this before. This pr adds the needed header. I've tested this from outside the corp network and it now seems to work. 

This should fix #27 