### PR TITLE
Add a travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+# Travis CI configuration file
+
+language: python
+dist: trusty
+python:
+  - 3.6
+virtualenv:
+    system_site_package: true
+script:
+    - pip install -r ./requirements.txt
+    - python -m unittest discover

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
This pull request adds support for running the unit tests each time a commit/pr is made. This eases any burden on running tests and checking future code contributions. You can also further integrate it with coveralls for code coverage stats. If you haven't played with Travis before, you can easily integrate your GitHub account to [their service](https://travis-ci.org).

I know there isn't an issue out for this, so feel free to reject or add suggestions.

### Addition of travis.yml
I set the current version of Python to test against as 3.6 however, you can add n different versions above/below it.

#### requirements.txt

The addition of this file shouldn't effect the pip install in any way, but gives developers and CI an easy way to install dependencies (see the `script:` section in travis.yml). I think that the `requests` package is also missing from the `setup.py`.

