### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ python:
 virtualenv:
     system_site_package: true
 script:
-    - pip install -r ./requirements.txt
-    - python -m unittest discover
     - make venv
     - make install
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,7 @@ virtualenv:
 script:
     - pip install -r ./requirements.txt
     - python -m unittest discover
-    - make
+    - make venv
+    - make install
+    - make test
+    - make dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ virtualenv:
 script:
     - pip install -r ./requirements.txt
     - python -m unittest discover
+    - make

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md') as readme_file:
 with open('HISTORY.md') as history_file:
     history = history_file.read()
 
-requirements = []
+requirements = ["requests"]
 
 setup(
     author='Wil Selwood',


### PR DESCRIPTION
This PR introduces a few small changes.

The first is that the tests are run via the makefile, which should cut down on any need for refactoring the travis file if the test commands are changed. The second is that travis now builds the package wheel as the last step. This should just provide as an early warning system for any code changes that actually break anything going on in setup.py

One note about the unit tests. I haven't been able to get them to run locally or on travis. When running `test_erroredRequest` I ran across.
```
Could not download test due to io error boom
...HTTP Error 401: Unauthorized
{"errorCode":401,"errorMessage":"Failed to sign in with the credentials provided"}
```

I removed all of the tests except for one and used my real credentials and still recieved 
```
HTTP Error 401: Unauthorized
{"errorCode":401,"errorMessage":"Failed to sign in with the credentials provided"}
```

Is this something that others are running across?